### PR TITLE
Add bundle identifier to Info.plist

### DIFF
--- a/MinuteMind/Info.plist
+++ b/MinuteMind/Info.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>CFBundleName</key>
     <string>MinuteMind</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>OPENAI_API_KEY</key>
     <string></string>
 </dict>


### PR DESCRIPTION
## Summary
- include CFBundleIdentifier in Info.plist to resolve missing bundle ID errors during installation

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b52922aa90832b8e25b1144e70495f